### PR TITLE
fix: don't overwrite AxiosRequestConfig headers

### DIFF
--- a/src/clients/functions.ts
+++ b/src/clients/functions.ts
@@ -25,8 +25,8 @@ export class NhostFunctionsClient {
     config?: AxiosRequestConfig
   ): Promise<FunctionCallResponse> {
     const headers = {
-      ...config?.headers,
       ...this.generateAccessTokenHeaders(),
+      ...config?.headers,
     };
 
     let res;


### PR DESCRIPTION
headers provided in the config AxiosRequestConfig should be considered higher priority and should not get overwritten by generateAccessTokenHeaders().
The issue in this case is particularly related to passing a custom Authorization Header. But the same issue can occur to other potential headers you might want to set explicitly through AxiosRequestConfig.

Even though Nhost might already have an accessToken in memory, a developer might want to make requests using a different Authorization access token at any given time.

nhost.functions.call(
        "your/endpoint",
        null,
        {
          method: "post",
          headers: { Authorization: `Bearer ${accessToken}` },
        }
      )